### PR TITLE
Merge Newmodel with main

### DIFF
--- a/2025/day_1/CircularDoublyLinkedList.go
+++ b/2025/day_1/CircularDoublyLinkedList.go
@@ -3,14 +3,14 @@ package main
 import "log"
 
 /*
-File DoublyCircularLinkedList.go implements a Doubly Circular Linked List.
+File CircularDoublyLinkedList.go implements a Doubly Circular Linked List.
 Made for Advent of Code 2025, this is not a full implementation of the data structures and methods.
 */
 
 /*
-Type DoublyCircularLinkedList is used for simulating a virtual dial.
+Type CircularDoublyLinkedList is used for simulating a virtual dial.
 */
-type DoublyCircularLinkedList struct {
+type CircularDoublyLinkedList struct {
 	Head   *Node
 	Tail   *Node
 	Length int
@@ -24,12 +24,13 @@ type Node struct {
 }
 
 // InsertBeginning places a Node at the start of the Circular Linked List and increments its length.
-func (cl *DoublyCircularLinkedList) InsertBeginning(n *Node) {
+func (cl *CircularDoublyLinkedList) InsertBeginning(n *Node) {
 	if cl.Head == nil {
 		cl.Head = n
 		cl.Tail = cl.Head
 		n.Right = cl.Head
 	} else {
+		cl.Head.Left = n // Previous node will point to new node.
 		n.Right = cl.Head
 		cl.Head = n
 		cl.Tail.Right = cl.Head
@@ -41,7 +42,7 @@ func (cl *DoublyCircularLinkedList) InsertBeginning(n *Node) {
 Find searches for a Node whose Index is equal to i and returns it.
 Crashes with log.Fatal if the Linked List is empty.
 */
-func (cl *DoublyCircularLinkedList) Find(i int) *Node {
+func (cl *CircularDoublyLinkedList) Find(i int) *Node {
 	if cl.Head == nil {
 		log.Fatal("Linked list is empty!")
 		return nil
@@ -49,13 +50,15 @@ func (cl *DoublyCircularLinkedList) Find(i int) *Node {
 
 	if cl.Head.Index == i {
 		return cl.Head
-	} else {
-		h := cl.Head
-		for h.Right != cl.Head {
-			h = h.Right
-			if h.Index == i {
-				return h
-			}
+	}
+
+	h := cl.Head
+	for h.Right != cl.Head {
+		h = h.Right
+		if h.Index == i {
+			return h
 		}
 	}
+
+	return nil
 }

--- a/2025/day_1/CircularDoublyLinkedList.go
+++ b/2025/day_1/CircularDoublyLinkedList.go
@@ -30,10 +30,11 @@ func (cl *CircularDoublyLinkedList) InsertBeginning(n *Node) {
 		cl.Tail = cl.Head
 		n.Right = cl.Head
 	} else {
-		cl.Head.Left = n // Previous node will point to new node.
+		cl.Head.Left = n
 		n.Right = cl.Head
 		cl.Head = n
 		cl.Tail.Right = cl.Head
+		cl.Head.Left = cl.Tail
 	}
 	cl.Length++
 }

--- a/2025/day_1/DoublyCircularLinkedList.go
+++ b/2025/day_1/DoublyCircularLinkedList.go
@@ -45,16 +45,17 @@ Crashes with log.Fatal if the Linked List is empty.
 func (cl *DoublyCircularLinkedList) Find(i int) *Node {
 	if cl.Head == nil {
 		log.Fatal("Linked list is empty!")
+		return nil
+	}
+
+	if cl.Head.Index == i {
+		return cl.Head
 	} else {
-		if cl.Head.Index == i {
-			return cl.Head
-		} else {
-			h := cl.Head
-			for h.Right != cl.Head {
-				h = h.Right
-				if h.Index == i {
-					return h
-				}
+		h := cl.Head
+		for h.Right != cl.Head {
+			h = h.Right
+			if h.Index == i {
+				return h
 			}
 		}
 	}

--- a/2025/day_1/DoublyCircularLinkedList.go
+++ b/2025/day_1/DoublyCircularLinkedList.go
@@ -8,8 +8,7 @@ Made for Advent of Code 2025, this is not a full implementation of the data stru
 */
 
 /*
-Type DoublyCircularLinkedList is used for simulating a virtual dial by setting point 0 as the head and 99 as the
-tail.
+Type DoublyCircularLinkedList is used for simulating a virtual dial.
 */
 type DoublyCircularLinkedList struct {
 	Head   *Node

--- a/2025/day_1/main.go
+++ b/2025/day_1/main.go
@@ -17,7 +17,15 @@ import (
 // If you want to run this code yourself, download the input file for Day 1 Part 1 and rename it to input-1.txt.
 func main() {
 	fmt.Println("AOC 2025 - Day 1!")
-	dial := 50
+
+	d := CircularDoublyLinkedList{Length: 100}
+	for i := 99; i > -1; i-- {
+		d.InsertBeginning(&Node{Index: i})
+	}
+	p := d.Head
+	for range 50 {
+		p = p.Right
+	}
 	count := 0
 
 	file, err := os.Open("input-1.txt")
@@ -30,34 +38,26 @@ func main() {
 	for _, line := range lines {
 		if string(line[0]) == "R" {
 			// Turn the dial right.
-			num, err := strconv.Atoi(line[1:])
+			r, err := strconv.Atoi(line[1:])
 			if err != nil {
 				log.Fatal(err)
 			}
-			dial += num
+			p = Right(p, r)
 		} else {
 			// Turn the dial left.
-			num, err := strconv.Atoi(line[1:])
+			l, err := strconv.Atoi(line[1:])
 			if err != nil {
 				log.Fatal(err)
 			}
-			dial -= num
+			p = Left(p, l)
 		}
 
-		// Var "dial" could be outside the range [0,99] which isn't legal in this puzzle.
-		dial = Over(dial)
-		dial = Under(dial)
-
-		if dial > 99 || dial < 0 {
-			log.Fatalf("Dial value is %v. Dial should not exceed 0 <= dial <= 99 ", dial)
-		}
-
-		if dial == 0 {
-			count += 1
+		if p.Index == 0 {
+			count++
 		}
 	}
 
-	fmt.Println(count)
+	fmt.Printf("Number of times zero was pointed at: %d.\n", count)
 }
 
 func getLines(f *os.File) []string {
@@ -75,18 +75,16 @@ func getLines(f *os.File) []string {
 	return lines
 }
 
-// Over subtracts 100 from n until 0 <= n <= 99.
-func Over(n int) int {
-	if n > 99 {
-		n = Over(n - 100)
+func Right(p *Node, n int) *Node {
+	for range n {
+		p = p.Right
 	}
-	return n
+	return p
 }
 
-// Under adds 100 to n until 0 <= n <= 99.
-func Under(n int) int {
-	if n < 0 {
-		n = Under(n + 100)
+func Left(p *Node, n int) *Node {
+	for range n {
+		p = p.Left
 	}
-	return n
+	return p
 }


### PR DESCRIPTION
In this pull request I am changing the data structures being used to solve AOC Day 1. The motivation for this was to make it easier to solve Part 2 of the Day 1 challenge.

The model switched from a basic integer to a Circular Doubly Linked List to represent the dial. Compound data types allow programmers to accurately model a problem environment.

The linked list is implemented with two methods:
- `InsertBeginning()`: Prepends elements to the head of the list.
- `Find`: Performs a linear search over the list in order to find an index that matches a given number.
(Note: I did not need to write `Find()`, this will be deleted once the merge request is resolved).

Two subroutines were written to simulate the dial rotations:
- Right(): Searches the next element in the list.
- Left(): Searches the previous element in the list.

Because of the circular nature of the Linked List, we do not need to apply additional logic to our program like we did with the integer. (E.g. To turn the dial by 68, the program started at 50, subtracted 68, then called a separate function to add back 100 until the value fell within the range `[0,99]`).

The program runs equally as fast on my personal machine, in both scenarios. The flexibility of the linked list made the main program logic much simpler to handle, so I consider this merge request a success.